### PR TITLE
feat: add geo search input

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "complexity": "off"
-  }
-}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/package.json
+++ b/package.json
@@ -22,16 +22,17 @@
   "author": "Espen Hovlandsdal",
   "license": "MIT",
   "dependencies": {
+    "esri-leaflet-geocoder": "2.3.4",
     "leaflet": "^1.6.0",
     "prop-types": "^15.7.2",
     "react-leaflet": "^2.6.3"
   },
   "devDependencies": {
-    "prettier": "2.0.4",
     "eslint": "6.8.0",
     "eslint-config-prettier": "6.10.1",
     "eslint-config-sanity": "1.149.0",
-    "eslint-plugin-react": "7.19.0"
+    "eslint-plugin-react": "7.19.0",
+    "prettier": "2.0.4"
   },
   "peerDependencies": {
     "react": "^16.2",

--- a/package.json
+++ b/package.json
@@ -22,17 +22,17 @@
   "author": "Espen Hovlandsdal",
   "license": "MIT",
   "dependencies": {
-    "esri-leaflet-geocoder": "2.3.4",
+    "esri-leaflet-geocoder": "^2.3.4",
     "leaflet": "^1.6.0",
     "prop-types": "^15.7.2",
     "react-leaflet": "^2.6.3"
   },
   "devDependencies": {
-    "eslint": "6.8.0",
-    "eslint-config-prettier": "6.10.1",
-    "eslint-config-sanity": "1.149.0",
-    "eslint-plugin-react": "7.19.0",
-    "prettier": "2.0.4"
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.1",
+    "eslint-config-sanity": "^1.149.0",
+    "eslint-plugin-react": "^7.19.0",
+    "prettier": "^2.0.4"
   },
   "peerDependencies": {
     "react": "^16.2",

--- a/src/GeoSearchPlugin.js
+++ b/src/GeoSearchPlugin.js
@@ -2,6 +2,7 @@ import {withLeaflet, MapControl} from 'react-leaflet'
 import {Geosearch} from 'esri-leaflet-geocoder'
 
 class LeafletGeoSearch extends MapControl {
+  // eslint-disable-next-line class-methods-use-this
   createLeafletElement(props) {
     const GeoSearch = new Geosearch()
 

--- a/src/GeoSearchPlugin.js
+++ b/src/GeoSearchPlugin.js
@@ -1,0 +1,26 @@
+import {withLeaflet, MapControl} from 'react-leaflet'
+import {Geosearch} from 'esri-leaflet-geocoder'
+
+class LeafletGeoSearch extends MapControl {
+  createLeafletElement(props) {
+    const GeoSearch = new Geosearch()
+
+    GeoSearch.on('results', ({latlng}) => {
+      props.onSelectLocation(latlng)
+    })
+
+    return GeoSearch
+  }
+
+  componentDidMount() {
+    const {map} = this.props.leaflet
+
+    this.leafletElement.addTo(map)
+  }
+
+  componentWillUnmount() {
+    this.leafletElement.remove()
+  }
+}
+
+export default withLeaflet(LeafletGeoSearch)

--- a/src/GeopointInput.js
+++ b/src/GeopointInput.js
@@ -8,6 +8,7 @@ import {PatchEvent, set, setIfMissing, unset} from 'part:@sanity/form-builder/pa
 import config from 'config:leaflet-input'
 import leafStyles from './Leaflet.css'
 import styles from './GeopointInput.css'
+import GeoSearchInput from './GeoSearchPlugin'
 import MapBoxAccessTokenMissing from './MapBoxAccessTokenMissing'
 
 Leaflet.Icon.Default.mergeOptions({
@@ -133,6 +134,8 @@ const GeopointInput = React.forwardRef(function GeopointInput(props, ref) {
               )}
             </Marker>
           )}
+
+          <GeoSearchInput onSelectLocation={setMarkerLocation} />
 
           <ZoomControl position="topright" />
         </Map>

--- a/src/Leaflet.css
+++ b/src/Leaflet.css
@@ -650,3 +650,178 @@
   margin-left: -12px;
   border-right-color: #fff;
 }
+
+/* GeoSearchInput */
+
+.leaflet :global(.geocoder-control-input) {
+  position: absolute;
+  left: 0;
+  top: 0;
+  background-color: white;
+  background-repeat: no-repeat;
+  background-image: url('esri-leaflet-geocoder/dist/img/search.png');
+  background-size: 26px;
+  border: none;
+  padding: 0;
+  text-indent: 6px;
+  font-size: 13px;
+  line-height: normal;
+  height: auto;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  width: 100%;
+  background-position: right center;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+.leaflet :global(.geocoder-control-input-disabled) {
+  background-color: #f4f4f4;
+  background-image: url('esri-leaflet-geocoder/dist/img/search-disabled.png');
+}
+
+.leaflet :global(.geocoder-control) {
+  width: 26px;
+  height: 26px;
+  -webkit-transition: width 0.175s ease-in;
+  -moz-transition: width 0.175s ease-in;
+  -ms-transition: width 0.175s ease-in;
+  -o-transition: width 0.175s ease-in;
+  transition: width 0.175s ease-in;
+}
+
+.leaflet :global(.geocoder-control-expanded),
+.leaflet :global(.leaflet-touch .geocoder-control-expanded) {
+  width: 275px;
+}
+
+.leaflet :global(.geocoder-control-input.geocoder-control-loading) {
+  background-image: url('esri-leaflet-geocoder/dist/img/loading.gif');
+  background-size: 26px;
+}
+
+@media only screen and (min--moz-device-pixel-ratio: 2),
+  only screen and (-o-min-device-pixel-ratio: 2 / 1),
+  only screen and (-webkit-min-device-pixel-ratio: 2),
+  only screen and (min-device-pixel-ratio: 2) {
+  .leaflet :global(.geocoder-control-input) {
+    background-image: url('esri-leaflet-geocoder/dist/img/search@2x.png');
+  }
+  .leaflet :global(.geocoder-control-input-disabled) {
+    background-image: url('esri-leaflet-geocoder/dist/img/search@2x-disabled.png');
+  }
+  .leaflet :global(.geocoder-control-input.geocoder-control-loading) {
+    background-image: url('esri-leaflet-geocoder/dist/img/loading@2x.gif');
+  }
+}
+
+.leaflet :global(.geocoder-control-input:focus) {
+  outline: none;
+  cursor: text;
+}
+
+.leaflet :global(.geocoder-control-input::-ms-clear) {
+  display: none;
+}
+
+.leaflet :global(.geocoder-control-suggestions) {
+  width: 100%;
+  position: absolute;
+  top: 26px;
+  left: 0;
+  margin-top: 10px;
+  overflow: auto;
+  display: none;
+}
+
+.leaflet :global(.geocoder-control-list + .geocoder-control-header) {
+  border-top: 1px solid #d5d5d5;
+}
+
+.leaflet :global(.geocoder-control-header) {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #444;
+  background: #f2f2f2;
+  border-bottom: 1px solid #d5d5d5;
+  display: block;
+  padding: 0.5em;
+}
+
+.leaflet :global(.geocoder-control-list) {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.leaflet :global(.geocoder-control-suggestions .geocoder-control-suggestion) {
+  font-size: 13px;
+  padding: 7px;
+  background: white;
+  border-top: 1px solid #f1f1f1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.leaflet :global(.geocoder-control-suggestions .geocoder-control-suggestion:first-child) {
+  border: none;
+}
+
+.leaflet
+  :global(.geocoder-control-suggestions .geocoder-control-suggestion.geocoder-control-selected),
+.leaflet :global(.geocoder-control-suggestions .geocoder-control-suggestion:hover) {
+  background: #7fdfff;
+  border-color: #7fdfff;
+}
+
+.leaflet :global(.leaflet-right .geocoder-control-suggestions) {
+  left: auto;
+  right: 0;
+}
+
+.leaflet :global(.leaflet-right .geocoder-control-input) {
+  left: auto;
+  right: 0;
+}
+
+.leaflet :global(.leaflet-bottom .geocoder-control-suggestions) {
+  margin-top: 0;
+  top: 0;
+}
+
+.leaflet :global(.leaflet-touch .geocoder-control) {
+  width: 34px;
+}
+
+.leaflet :global(.leaflet-touch .geocoder-control.geocoder-control-expanded) {
+  width: 275px;
+}
+
+.leaflet :global(.leaflet-touch .geocoder-control-input) {
+  height: 34px;
+  line-height: 30px;
+  background-size: 30px;
+}
+
+.leaflet :global(.leaflet-touch .geocoder-control-suggestions) {
+  top: 30px;
+  width: 271px;
+}
+
+.leaflet :global(.leaflet-oldie .geocoder-control-input) {
+  width: 28px;
+  height: 28px;
+}
+
+.leaflet :global(.leaflet-oldie .geocoder-control-expanded .geocoder-control-input) {
+  width: auto;
+}
+
+.leaflet :global(.leaflet-oldie .geocoder-control-input),
+.leaflet :global(.leaflet-oldie .geocoder-control-suggestions) {
+  border: 1px solid #999;
+}


### PR DESCRIPTION
## Description

This PR adds a new GeoSearchInput component that helps users select a location, inspired by this [React plugin](https://github.com/slutske22/react-esri-leaflet/blob/master/src-v2/plugins/EsriLeafletGeoSearch.js).

Closes #2.

## Notes


1. In order to build and test locally with [`sanipack`](https://github.com/rexxars/sanipack), I had to install `@babel/cli` and `@babel/core`.
Should I add them as dependencies to the project, or is `sanipack` going to handle them in the future?

2. I got the styles working by copying the CSS file from `esri-leaflet-geocoder`'s dist folder.
Then I updated them with `.leaflet :global($selector)` and updated the URL for images - inspired by the `Leaflet.css` file.
Is there any other way to accomplish the same?