### PR TITLE
updated readme, removed requirement for lat/long field

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ In your studios `config/leaflet-input.json` file (if it's missing, run `sanity s
 ```json
 {
   "tileLayer": {
+    "attribution": "© <a href=\"https://www.mapbox.com/about/maps/\">Mapbox</a> © <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> <strong><a href=\"https://www.mapbox.com/map-feedback/\" target=\"_blank\">Improve this map</a></strong>",
+    "url": "https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}",
     "accessToken": "SOME_ACCESS_TOKEN",
-    "id": "mapbox.streets",
+    "tileSize": 512,
     "maxZoom": 18,
-    "url": "https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}",
-    "attribution": "© <a href=\"https://www.mapbox.com/about/maps/\">Mapbox</a> © <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> <strong><a href=\"https://www.mapbox.com/map-feedback/\" target=\"_blank\">Improve this map</a></strong>"
+    "zoomOffset": -1,
+    "id": "mapbox/streets-v11"
   }
 }
 ```

--- a/src/GeopointInput.js
+++ b/src/GeopointInput.js
@@ -150,8 +150,8 @@ const GeopointInput = React.forwardRef(function GeopointInput(props, ref) {
 GeopointInput.propTypes = {
   value: PropTypes.shape({
     _type: PropTypes.string.isRequired,
-    lat: PropTypes.number.isRequired,
-    lng: PropTypes.number.isRequired,
+    lat: PropTypes.number,
+    lng: PropTypes.number,
   }),
   level: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/src/GeopointInput.js
+++ b/src/GeopointInput.js
@@ -68,15 +68,17 @@ const GeopointInput = React.forwardRef(function GeopointInput(props, ref) {
   }
 
   function setMarkerLocation(latLng) {
-    onChange(
-      PatchEvent.from([
-        setIfMissing({
-          _type: type.name,
-        }),
-        set(latLng.lat, ['lat']),
-        set(latLng.lng, ['lng']),
-      ])
-    )
+    if(latLng){
+      onChange(
+        PatchEvent.from([
+          setIfMissing({
+            _type: type.name,
+          }),
+          set(latLng.lat, ['lat']),
+          set(latLng.lng, ['lng']),
+        ])
+      )
+    }
   }
 
   function handleMapClick(evt) {

--- a/src/GeopointInput.js
+++ b/src/GeopointInput.js
@@ -68,18 +68,15 @@ const GeopointInput = React.forwardRef(function GeopointInput(props, ref) {
   }
 
   function setMarkerLocation(latLng) {
-    console.log(latLng)
-    if(latLng && latLng.lat){
-      onChange(
-        PatchEvent.from([
-          setIfMissing({
-            _type: type.name,
-          }),
-          set(latLng.lat, ['lat']),
-          set(latLng.lng, ['lng']),
-        ])
-      )
-    }
+    onChange(
+      PatchEvent.from([
+        setIfMissing({
+          _type: type.name,
+        }),
+        set(latLng.lat, ['lat']),
+        set(latLng.lng, ['lng']),
+      ])
+    )
   }
 
   function handleMapClick(evt) {

--- a/src/GeopointInput.js
+++ b/src/GeopointInput.js
@@ -68,7 +68,8 @@ const GeopointInput = React.forwardRef(function GeopointInput(props, ref) {
   }
 
   function setMarkerLocation(latLng) {
-    if(latLng){
+    console.log(latLng)
+    if(latLng && latLng.lat){
       onChange(
         PatchEvent.from([
           setIfMissing({


### PR DESCRIPTION
### Summary
This fix updates 2 things. First, it updates the readme to provide an example config when using Mapbox as the mapping provider using their new v2 api.

Second, it removes 2 required fields (latitude and longitude) which break search when using mapbox.

### Testing

Tested this locally with my own studio when using a fork of this package and specifying the fork in my package.json